### PR TITLE
Added an error message print out

### DIFF
--- a/athena_from_s3.py
+++ b/athena_from_s3.py
@@ -35,6 +35,8 @@ def query_results(session, params, wait = True):
             status = response_get_query_details['QueryExecution']['Status']['State']
             
             if (status == 'FAILED') or (status == 'CANCELLED') :
+                failure_reason = response_get_query_details['QueryExecution']['Status']['StateChangeReason']
+                print(failure_reason)
                 return False, False
 
             elif status == 'SUCCEEDED':


### PR DESCRIPTION
Before, it was hard to debug why the Athena queries were not working. This offers some better clarity on that in the case that a failure is detected.